### PR TITLE
Update Mezzanine to 4.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@ bleach==2.0.0
 chardet==2.3.0
 Django==1.10.6
 django-contrib-comments==1.8.0
-filebrowser-safe==0.4.7
+filebrowser-safe==0.5.0
 future==0.16.0
-grappelli-safe==0.4.6
+grappelli-safe==0.5.0
 html5lib==0.999999999
-Mezzanine==4.2.3
+Mezzanine==4.3.1
 oauthlib==2.0.1
 olefile==0.44
 packaging==16.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.3
 beautifulsoup4==4.5.3
 bleach==2.0.0
 chardet==2.3.0
-Django==1.10.6
+Django==1.11.18
 django-contrib-comments==1.8.0
 filebrowser-safe==0.5.0
 future==0.16.0


### PR DESCRIPTION
Seems like a good idea to bring this up to date a bit. 

I've updated:
Mezzanine to 4.3.1
Django to 1.11.18, which is an LTS release

Mezzanine 4.3.1 also needed grappelli-safe and filebrowser-safe both updated to 0.5.0