### PR TITLE
Database persistence fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+.hgignore
+.DS_Store
+.coverage
+README.md
+datavolume
+deploy

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .coverage
 local_settings.py
 /static
+/datavolume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   db:
     image: postgres
     volumes:
-      - ./datavolume:/var/lib/postgresql
+      - ./datavolume:/var/lib/postgresql/data
   web:
     build: .
     command: ./wait-for-it.sh db:5432 -t 30 -- python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
The upstream docker-compose.yaml makes an attempt at mounting the Postgres data from the `datavolume` folder in the working directory, however this does not work with the Postgres image because the actual `data` subdirectory is already mounted as an anonymous volume. 

This is fixed by setting the path directly to the data directory rather than the parent `postgresql` directory. 

I've added the `datavolume` dir to gitignore since it seems unlikely you'd want this stuff in git, but I'll admit I don't understand the intended deployment method (I'm working on my own production ready docker-compose configuration). I'd be happy to remove it if you disagree?

I've also included a dockerignore file as a recommended best practise, to prevent the database and other unnecessary resources being included in the container image. 


I hope these have been helpful, this will probably be my last one for a while as move on to getting my site up and running. Thanks for this excellent starting template. 